### PR TITLE
Fix adding member while they are in claim

### DIFF
--- a/src/main/java/com/craftaro/ultimateclaims/claim/Claim.java
+++ b/src/main/java/com/craftaro/ultimateclaims/claim/Claim.java
@@ -175,14 +175,15 @@ public class Claim {
     }
 
     public ClaimMember addMember(ClaimMember member) {
+        // Removing the player if they already are a member (i.e. they are a visitor) to avoid conflict
+        this.removeMember(member.getUniqueId());
         this.members.add(member);
         return member;
     }
 
     public ClaimMember addMember(OfflinePlayer player, ClaimRole role) {
         ClaimMember newMember = new ClaimMember(this, player.getUniqueId(), player.getName(), role);
-        this.members.add(newMember);
-        return newMember;
+        return addMember(newMember);
     }
 
     public ClaimMember getMember(UUID uuid) {


### PR DESCRIPTION
There is a bug where a player being added as a member to a claim while they are currently within the claim boundary will cause them to be registered as both an visitor and a member. This causes commands such as /c kick <player> to not work 

Steps to reproduce:
* P1: /c create
* P2: Stand within created claim
* P1: /c addmember P2
* If you look in the members list within the powercell, you will see P2 listed twice
* P1: /c kick P2 - This will not allow you to kick them as they are not seen as a member

This PR fixes the problem by removing any existing members linked with that players UUID when adding them as a new ClaimMember. 