### PR TITLE
Fix cyclic plugin loading

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,8 +4,6 @@ version: ${project.version}
 api-version: 1.13
 
 main: com.craftaro.ultimateclaims.UltimateClaims
-loadbefore:
-  - WorldGuard
 softdepend:
   - CMI
   - DecentHolograms


### PR DESCRIPTION
Using the flag to ignore this is not a proper solution and also breaks hooks between other plugins on the server. Worldguard don't use the API of UltimateClaims so there is no point of that loadbefore.