### PR TITLE
Updated Paper Maven repo URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <!-- Required for Essentials -->
         <repository>
             <id>paper-repo</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The Paper Maven repository has moved from https://papermc.io/repo/repository/maven-public/ to https://repo.papermc.io/repository/maven-public/. The old URL now returns an error telling you to use the new one instead.